### PR TITLE
spec file fix for RHEL6

### DIFF
--- a/naemon.spec
+++ b/naemon.spec
@@ -49,6 +49,7 @@ BuildRequires: expat-devel
 # rhel6 specific requirements
 %if 0%{?el6}
 BuildRequires: perl-ExtUtils-MakeMaker
+BuildRequires: perl-Module-Install
 %endif
 %if 0%{?el7}%{?fc20}%{?fc21}%{?fc22}
 BuildRequires: perl-autodie


### PR DESCRIPTION
RHEL6 requires perl-Module-Install to build Thruk.
