### PR TITLE
Modified spec file to work properly with openSuSE 12.3 and above.

### DIFF
--- a/naemon.spec
+++ b/naemon.spec
@@ -59,12 +59,12 @@ BuildRequires: systemd
 BuildRequires: chrpath
 %endif
 
-%if 0%{suse_version} < 1230
+%if %{defined suse_version}
+% if 0%{suse_version} < 1230
 Requires(pre): pwdutils
-%else
+% else
 Requires(pre): shadow
-%endif
-%if %{undefined suse_version}
+% endif
 Requires(pre): shadow-utils
 %endif
 Requires: %{name}-core            = %{version}-%{release}


### PR DESCRIPTION
openSuse changed their password and group utilities as of 12.3 to be
more in line with other redhat variants.   The package name also changed
from 'pwdutils' to 'shadow' as of 12.3.
