### PR TITLE
travis: git tags are no longer pulled in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
   - git config --global user.email "travis@localhost"
   - git config --global user.name "Travis Testuser"
+  - git fetch --all -t
   - make dailyversion
   - ./configure    || exit 1
   - make           || exit 1


### PR DESCRIPTION
so do this manually in order to make ./get_version work. Since
./get_version relies on git tags we need at least one git tag.

Signed-off-by: Sven Nierlein sven@nierlein.de
