### PR TITLE
livestatus: Use pkg-config file provided by naemon-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ naemon-core:
 	cd naemon-core && make
 
 naemon-livestatus:
-	cd naemon-livestatus && make CPPFLAGS="$$CPPFLAGS -I$$(pwd)/../naemon-core/src"
+	cd naemon-livestatus && make CPPFLAGS="$$CPPFLAGS"
 
 update: update-naemon-core update-naemon-livestatus
 	@if [ `git status 2>/dev/null | grep -c "new commits"` -gt 0 ]; then \

--- a/configure
+++ b/configure
@@ -27,7 +27,7 @@ test -f ./configure || autoreconf -i
 
 cd ../naemon-livestatus
 test -f ./configure || autoreconf -i
-NAEMON_LIBS="-L$(pwd)/../naemon-core" NAEMON_CFLAGS="-I$(pwd)/../naemon-core" ./configure $*
+PKG_CONFIG_PATH="$(pwd)/../naemon-core" ./configure $*
 
 echo "***************************************"
 echo "finished configuring Naemon."


### PR DESCRIPTION
It is not a good idea to hard code the NAEMON_LIBS & NAEMON_CFLAGS,
since it is liable to break when those change in the naemon-core project
itself.

Signed-off-by: Anton Lofgren <alofgren@op5.com>