### PR TITLE
fix E: invalid-license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - sudo apt-get install build-essential
   - sudo apt-get install gperf
   - sudo apt-get install libgd2-xpm-dev
+  - sudo apt-get install fakeroot
   - sudo apt-get install devscripts
   - sudo apt-get install dh-make
   - sudo apt-get install asciidoc

--- a/naemon.spec
+++ b/naemon.spec
@@ -12,7 +12,7 @@ Summary: Open Source Host, Service And Network Monitoring Program
 Name: naemon
 Version: 1.0.10
 Release: 0
-License: GPLv2
+License: GPL-2.0-only
 BuildArch: noarch
 Group: Applications/System
 URL: http://www.naemon.org/


### PR DESCRIPTION
same issue as in naemon/naemon-core#317

GPLv2 is not a valid license according to rpmlint and https://spdx.org/licenses/