### PR TITLE
apache2 is required to build meta package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: naemon
 Section: net
 Priority: optional
 Maintainer: Naemon Core Development Team <naemon-dev@monitoring-lists.org>
-Build-Depends: debhelper (>= 9), fakeroot, make
+Build-Depends: debhelper (>= 9), fakeroot, make, apache2
 Standards-Version: 3.7.3
 Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon/issues

--- a/debian/naemon.dsc
+++ b/debian/naemon.dsc
@@ -7,7 +7,7 @@ Homepage: http://www.naemon.org
 Bugs: https://github.com/naemon/naemon/issues
 Vcs-Browser: https://github.com/naemon/naemon
 Vcs-Git: git://github.com:naemon/naemon-core.git
-Build-Depends: debhelper (>= 9), fakeroot, make
+Build-Depends: debhelper (>= 9), fakeroot, make, apache2
 Files:
    00000000000000000000000000000000 0000 naemon_1.0.0.orig.tar.gz
    00000000000000000000000000000000 0000 naemon_1.0.0-1.diff.tar.gz


### PR DESCRIPTION
Otherwise apache config files will not be build and missing.
This is the case for rpm builds already, but missing for debian
and ubuntu.