### PR TITLE
spec: relax Naemon dependency version requirements

### DIFF
--- a/naemon.spec
+++ b/naemon.spec
@@ -25,10 +25,10 @@ BuildRequires: apache2
 %else
 BuildRequires: httpd
 %endif
-Requires: %{name}-core            >= %{version}-%{release}
-Requires: %{name}-livestatus      >= %{version}-%{release}
-Requires: %{name}-vimvault        >= %{version}-%{release}
-Requires: %{name}-thruk           = %{version}-%{release}
+Requires: %{name}-core            >= %{version}
+Requires: %{name}-livestatus      >= %{version}
+Requires: %{name}-vimvault        >= %{version}
+Requires: %{name}-thruk           = %{version}
 
 # do not generate debug packages
 %define debug_package %{nil}


### PR DESCRIPTION
When building with OBS, we do not control the `release` part of the
version number, and it may not always match across the different
packages.

To ensure the dependencies can always be correctly met, we just rely on
the version (i.e 1.3.0).

Signed-off-by: Jacob Hansen <jhansen@op5.com>