### PR TITLE
thruk business process requires an additional link

### DIFF
--- a/debian/naemon-thruk.postinst
+++ b/debian/naemon-thruk.postinst
@@ -30,6 +30,7 @@ case "$1" in
         [ ! -e /etc/naemon/menu_local.conf ]  || sed -e 's%/usr/share/naemon/%/usr/share/thruk/%g' -i /etc/naemon/menu_local.conf
         [ ! -e /etc/naemon/menu_local.conf ]  || mv /etc/naemon/menu_local.conf  /etc/thruk/menu_local.conf
         [ ! -e /etc/naemon/htpasswd ]         || mv /etc/naemon/htpasswd         /etc/thruk/htpasswd
+        [ -e /etc/naemon/conf.d/thruk_templates.cfg ] || ln -s /usr/share/thruk/support/thruk_templates.cfg /etc/naemon/conf.d/thruk_templates.cfg
 
         if $CONFIGURE_APACHE; then
             # enable naemon redirect

--- a/debian/naemon-thruk.postrm
+++ b/debian/naemon-thruk.postrm
@@ -22,6 +22,7 @@ set -e
 case "$1" in
     remove)
         rm -f /etc/apache2/conf-enabled/naemon.conf
+        rm -f /etc/naemon/conf.d/thruk_templates.cfg
     ;;
     upgrade)
     ;;

--- a/naemon.spec
+++ b/naemon.spec
@@ -86,6 +86,7 @@ mkdir -p -m 0755 /etc/thruk/
 [ ! -e %{_sysconfdir}/%{name}/menu_local.conf ]  || sed -e 's%/usr/share/naemon/%/usr/share/thruk/%g' -i %{_sysconfdir}/%{name}/menu_local.conf
 [ ! -e %{_sysconfdir}/%{name}/menu_local.conf ]  || %{__mv} %{_sysconfdir}/%{name}/menu_local.conf  /etc/thruk/menu_local.conf
 [ ! -e %{_sysconfdir}/%{name}/htpasswd ]         || %{__mv} %{_sysconfdir}/%{name}/htpasswd         /etc/thruk/htpasswd
+[ -e %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg ] || ln -s /usr/share/thruk/support/thruk_templates.cfg %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg
 
 # add apache user to group naemon so thruk can access the livestatus socket
 if /usr/bin/id %{apacheuser} &>/dev/null; then
@@ -125,6 +126,7 @@ case "$*" in
   0)
     # POSTUN
     rm -f %{_sysconfdir}/%{apachedir}/conf-enabled/naemon.conf
+    rm -f %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg
     ;;
   1)
     # POSTUPDATE


### PR DESCRIPTION
Otherwise the generated config is incomplete. Add the missing
link in the post-inst parts of the spec/deb files. And remove
it again in the postrm scripts.