### PR TITLE
fix creating postinst symlinks

### DIFF
--- a/debian/naemon-thruk.postinst
+++ b/debian/naemon-thruk.postinst
@@ -30,7 +30,7 @@ case "$1" in
         [ ! -e /etc/naemon/menu_local.conf ]  || sed -e 's%/usr/share/naemon/%/usr/share/thruk/%g' -i /etc/naemon/menu_local.conf
         [ ! -e /etc/naemon/menu_local.conf ]  || mv /etc/naemon/menu_local.conf  /etc/thruk/menu_local.conf
         [ ! -e /etc/naemon/htpasswd ]         || mv /etc/naemon/htpasswd         /etc/thruk/htpasswd
-        [ -e /etc/naemon/conf.d/thruk_templates.cfg ] || ln -s /usr/share/thruk/support/thruk_templates.cfg /etc/naemon/conf.d/thruk_templates.cfg
+        [ -e /etc/naemon/conf.d/thruk_templates.cfg ] || ln -sfn /usr/share/thruk/support/thruk_templates.cfg /etc/naemon/conf.d/thruk_templates.cfg
 
         if $CONFIGURE_APACHE; then
             # enable naemon redirect

--- a/naemon.spec
+++ b/naemon.spec
@@ -86,7 +86,7 @@ mkdir -p -m 0755 /etc/thruk/
 [ ! -e %{_sysconfdir}/%{name}/menu_local.conf ]  || sed -e 's%/usr/share/naemon/%/usr/share/thruk/%g' -i %{_sysconfdir}/%{name}/menu_local.conf
 [ ! -e %{_sysconfdir}/%{name}/menu_local.conf ]  || %{__mv} %{_sysconfdir}/%{name}/menu_local.conf  /etc/thruk/menu_local.conf
 [ ! -e %{_sysconfdir}/%{name}/htpasswd ]         || %{__mv} %{_sysconfdir}/%{name}/htpasswd         /etc/thruk/htpasswd
-[ -e %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg ] || ln -s /usr/share/thruk/support/thruk_templates.cfg %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg
+[ -e %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg ] || ln -sfn /usr/share/thruk/support/thruk_templates.cfg %{_sysconfdir}/%{name}/conf.d/thruk_templates.cfg
 
 # add apache user to group naemon so thruk can access the livestatus socket
 if /usr/bin/id %{apacheuser} &>/dev/null; then


### PR DESCRIPTION
seems like postinst scripts should be idempotent, so make sure we replace existing links.

```
[   29s] ... running 50-check-installtest
[   29s] ... testing for pre/postinstall scripts that are not idempotent
[   29s] ln: failed to create symbolic link '/etc/naemon/conf.d/thruk_templates.cfg': File exists
[   29s] postinstall script of naemon-thruk-1.3.1.2+20220607~9a8fc6d-lp153.41.1.noarch.rpm failed
```